### PR TITLE
Fix iOS issue

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -140,6 +140,8 @@ class _MyAppState extends State<MyApp> {
           _result = "Private Key : ${response.privateKey}";
           log(response.publicAddress);
         });
+      } on MissingParamException catch (error) {
+        log("Missing Param: ${error.paramName}");
       } on PrivateKeyNotGeneratedException {
         log("Private key not generated");
       } on UnKnownException {

--- a/ios/Classes/SingleFactorAuthFlutterPlugin.swift
+++ b/ios/Classes/SingleFactorAuthFlutterPlugin.swift
@@ -76,6 +76,7 @@ public class SingleFactorAuthFlutterPlugin: NSObject, FlutterPlugin {
                 guard let data = args?.data(using: .utf8) else {
                     return result(throwKeyNotGeneratedError())
                 }
+
                 let params = try self.decoder.decode(getTorusKeyParams.self, from: data)
                 
                 let loginParams = LoginParams(
@@ -85,6 +86,7 @@ public class SingleFactorAuthFlutterPlugin: NSObject, FlutterPlugin {
                 )
                 
                 do {
+                  
                     let torusKeyCF = try await singleFactorAuth?.getKey(
                         loginParams: loginParams
                     )
@@ -105,8 +107,12 @@ public class SingleFactorAuthFlutterPlugin: NSObject, FlutterPlugin {
                 
                 let params = try self.decoder.decode(getTorusKeyParams.self, from: data)
                 
+                guard let aggregateVerifier = params.aggregateVerifier else {
+                   return result(throwParamMissingError(param: "aggregateVerifier"))
+                }
+                
                 let loginParams = LoginParams(
-                    verifier: params.aggregateVerifier,
+                    verifier: params.aggregateVerifier!,
                     verifierId: params.verifierId,
                     idToken: params.idToken,
                     subVerifierInfoArray: [
@@ -140,6 +146,12 @@ public class SingleFactorAuthFlutterPlugin: NSObject, FlutterPlugin {
         )
     }
     
+    public func throwParamMissingError(param: String) -> FlutterError {
+        return FlutterError(
+            code: "missing_param", message: param, details: nil
+        )
+    }
+    
 }
 
 struct InitParams: Codable {
@@ -150,5 +162,5 @@ struct getTorusKeyParams: Codable {
     var verifier: String
     var verifierId: String
     var idToken: String
-    var aggregateVerifier: String
+    var aggregateVerifier: String?
 }

--- a/lib/input.dart
+++ b/lib/input.dart
@@ -39,6 +39,13 @@ class UserCancelledException implements Exception {}
 
 class PrivateKeyNotGeneratedException implements Exception {}
 
+class MissingParamException implements Exception {
+  final String paramName;
+
+  MissingParamException({required this.paramName});
+
+}
+
 class UnKnownException implements Exception {
   final String? message;
 

--- a/lib/single_factor_auth_flutter.dart
+++ b/lib/single_factor_auth_flutter.dart
@@ -73,6 +73,8 @@ class SingleFactAuthFlutter {
         throw UnKnownException(e.message);
       case "key_not_generated":
         throw PrivateKeyNotGeneratedException();
+      case "missing_param":
+        throw MissingParamException(paramName: e.message!);
       default:
         throw e;
     }


### PR DESCRIPTION
## Description 

Currently, we are expecting aggregateVerifier as a non nullable field for getKey and getAggregateKey. During getKey call, we don't send aggregateVerifier to swift side which results in decoding problem to struct. Due to this, getKey fails and doesn't send any result or error back to swift. 