### PR TITLE
Swift better error handling

### DIFF
--- a/ios/Classes/SingleFactorAuthFlutterPlugin.swift
+++ b/ios/Classes/SingleFactorAuthFlutterPlugin.swift
@@ -46,7 +46,7 @@ public class SingleFactorAuthFlutterPlugin: NSObject, FlutterPlugin {
             case "init":
                 let args = call.arguments as? String
                 guard let data = args?.data(using: .utf8) else {
-                    return result(throwKeyNotGeneratedError())
+                    return result(throwParamMissingError(param: args!))
                 }
                 
                 let params = try self.decoder.decode(InitParams.self, from: data)
@@ -74,13 +74,17 @@ public class SingleFactorAuthFlutterPlugin: NSObject, FlutterPlugin {
                     let resultJson = String(decoding: resultData, as: UTF8.self)
                     return result(resultJson)
                 } catch {
-                    result(throwKeyNotGeneratedError())
+                    result(FlutterError(
+                                code: (error as NSError).domain,
+                                message: error.localizedDescription,
+                                details: nil
+                           ))
                 }
                 
             case "connect":
                 let args = call.arguments as? String
                 guard let data = args?.data(using: .utf8) else {
-                    return result(throwKeyNotGeneratedError())
+                    return result(throwParamMissingError(param: args!))
                 }
 
                 let params = try self.decoder.decode(getTorusKeyParams.self, from: data)
@@ -116,7 +120,11 @@ public class SingleFactorAuthFlutterPlugin: NSObject, FlutterPlugin {
                     let resultJson = String(decoding: resultData, as: UTF8.self)
                     return result(resultJson)
                 } catch {
-                    result(throwKeyNotGeneratedError())
+                    result(FlutterError(
+                                code: (error as NSError).domain,
+                                message: error.localizedDescription,
+                                details: nil
+                            ))
                 }
                 break
 
@@ -129,7 +137,11 @@ public class SingleFactorAuthFlutterPlugin: NSObject, FlutterPlugin {
                         return result(isSessionExists)
                     }
                 } catch {
-                    result(throwKeyNotGeneratedError())
+                    result(FlutterError(
+                                 code: (error as NSError).domain,
+                                 message: error.localizedDescription,
+                                 details: nil
+                           ))
                 }
                 break
 

--- a/ios/Classes/SingleFactorAuthFlutterPlugin.swift
+++ b/ios/Classes/SingleFactorAuthFlutterPlugin.swift
@@ -77,7 +77,7 @@ public class SingleFactorAuthFlutterPlugin: NSObject, FlutterPlugin {
                     result(FlutterError(
                                 code: (error as NSError).domain,
                                 message: error.localizedDescription,
-                                details: nil
+                                details: String(describing: error)
                            ))
                 }
                 
@@ -123,7 +123,7 @@ public class SingleFactorAuthFlutterPlugin: NSObject, FlutterPlugin {
                     result(FlutterError(
                                 code: (error as NSError).domain,
                                 message: error.localizedDescription,
-                                details: nil
+                                details: String(describing: error)
                             ))
                 }
                 break
@@ -140,7 +140,7 @@ public class SingleFactorAuthFlutterPlugin: NSObject, FlutterPlugin {
                     result(FlutterError(
                                  code: (error as NSError).domain,
                                  message: error.localizedDescription,
-                                 details: nil
+                                 details: String(describing: error)
                            ))
                 }
                 break

--- a/ios/Classes/SingleFactorAuthFlutterPlugin.swift
+++ b/ios/Classes/SingleFactorAuthFlutterPlugin.swift
@@ -46,7 +46,7 @@ public class SingleFactorAuthFlutterPlugin: NSObject, FlutterPlugin {
             case "init":
                 let args = call.arguments as? String
                 guard let data = args?.data(using: .utf8) else {
-                    return result(throwParamMissingError(param: args!))
+                    return result(throwParamMissingError(param: args))
                 }
                 
                 let params = try self.decoder.decode(InitParams.self, from: data)
@@ -84,7 +84,7 @@ public class SingleFactorAuthFlutterPlugin: NSObject, FlutterPlugin {
             case "connect":
                 let args = call.arguments as? String
                 guard let data = args?.data(using: .utf8) else {
-                    return result(throwParamMissingError(param: args!))
+                    return result(throwParamMissingError(param: args))
                 }
 
                 let params = try self.decoder.decode(getTorusKeyParams.self, from: data)
@@ -151,13 +151,7 @@ public class SingleFactorAuthFlutterPlugin: NSObject, FlutterPlugin {
         }
     }
     
-    public func throwKeyNotGeneratedError() -> FlutterError {
-        return FlutterError(
-            code: "key_not_generated", message: "Key not generated", details: nil
-        )
-    }
-    
-    public func throwParamMissingError(param: String) -> FlutterError {
+    public func throwParamMissingError(param: String?) -> FlutterError {
         return FlutterError(
             code: "missing_param", message: param, details: nil
         )


### PR DESCRIPTION
## Motivation and Context
Swift better error handling

Jira Link:


## Description
* Swift better error handling.
* Previously there is generic error everytime "privateKeyNot Generated Error" but after update it gives exact error like "retrieve or import share failed" in screenshot.


## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
<img width="1011" alt="Screenshot 2024-11-07 at 11 30 00 AM" src="https://github.com/user-attachments/assets/e5eda987-a88d-4de6-a0e3-84887956b345">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code requires a db migration.
